### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken'
 import { cookies } from 'next/headers'
 
 export const randomUnsplashImageURL = (sig: string, width: number, height: number) =>
-  `https://source.unsplash.com/random/${width}x${height}?goose&sig=${sig}`
+  `https://picsum.photos/seed/goose-${sig}/${width}/${height}`
 
 export const decodeJWTFromCookie = () => {
   const jwtToken = cookies().get('jwtToken')


### PR DESCRIPTION
`src/helpers/index.tsx` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Rewrites the `randomUnsplashImageURL` helper so the generated URL uses `picsum.photos/seed/<key>/<W>/<H>` instead of the deprecated endpoint, restoring the intended per-`sig` deterministic goose-themed image.

#### Replacement details

The `sig` parameter is preserved as part of the seed, so each call with the same `sig` still returns the same image (matching the original helper's intent). `goose-` is kept in the seed key as a nod to the original query hint, though picsum doesn't support topic matching. If topic-matched geese matter for this UI, swap the helper's body for a fetch against the tteg HTTP API's `q=goose` endpoint — 1-line change, no SDK.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights this same broken-URL pattern in any landing page — useful for verifying the fix lands and for finding other places `source.unsplash.com/random` slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
